### PR TITLE
Fixed some issue. some chinese word output error pinyin: Zuo.

### DIFF
--- a/pinyin.go
+++ b/pinyin.go
@@ -1,6 +1,6 @@
 package pinyin
 
-import (	
+import (
 	"regexp"
 )
 
@@ -9,34 +9,34 @@ var hzRegexp = regexp.MustCompile("^[\u4e00-\u9fa5]$")
 
 //get chinese pinyin number code
 //param s must be chinese character with utf8 encoding
-func Code(s string) int{
-	gbkString := UTF8ToGBK(s)			
-	var i1,i2 int
+func Code(s string) int {
+	gbkString := UTF8ToGBK(s)
+	var i1, i2 int
 	i1 = int(gbkString[0])
 	i2 = int(gbkString[1])
 	return i1*256 + i2 - 65536
 }
-
 
 // convert chinese to pinyin
 func Convert(s string) string {
 	pyString := ""
 	var str string
 	var code int
-	 
 
 	for _, rune := range s {
 		str = string(rune)
-		if hzRegexp.MatchString(str) {//chinese
-			
-			code=Code(str)
-			
+		if hzRegexp.MatchString(str) { //chinese
+
+			code = Code(str)
+
 			if code > 0 && code < 160 {
 				pyString += str
 			} else {
-				if v, ok := tableMap[code]; ok {//map by table
+
+				if v, ok := tableMap[code]; ok { //map by table
 					pyString += v
 				} else {
+
 					for i := (pyValue_length - 1); i >= 0; i-- {
 
 						if pyValue[i] <= code {
@@ -46,10 +46,10 @@ func Convert(s string) string {
 					}
 				}
 			}
-		} else {//other
+		} else { //other
 			pyString += str
 		}
 	}
+
 	return pyString
 }
-

--- a/pinyin_test.go
+++ b/pinyin_test.go
@@ -4,13 +4,27 @@ import (
 	"testing"
 )
 
+/*
+Add following test case for last version: 204-03-08
+str:莞, code:-8776
+str:濮, code:-6745
+str:泸, code:-7182
+str:漯, code:-6928
+str:亳, code:-9743
+str:儋, code:-9767
+*/
 var pinyinTests = map[string]string{
 	"hello,世界!": "hello,ShiJie!",
 	"中文":        "ZhongWen",
 	"汉字":        "HanZi",
 	"拼音":        "PinYin",
 	"简体字":       "JianTiZi",
-	
+	"莞":         "Wan",
+	"濮":         "Pu",
+	"泸":         "Lu",
+	"漯":         "Luo",
+	"亳":         "Bo",
+	"儋":         "Dan",
 }
 
 func TestConvert(t *testing.T) {

--- a/table.go
+++ b/table.go
@@ -1,11 +1,27 @@
 package pinyin
 
 //code->pinyin mapping table
+/*
+By github.com/leonzhu1981
+Add following key,value for last version: 204-03-08
+str:莞, code:-8776
+str:濮, code:-6745
+str:泸, code:-7182
+str:漯, code:-6928
+str:亳, code:-9743
+str:儋, code:-9767
+*/
 var tableMap = map[int]string{
-	-7995: "En",
-	-9254: "Zhen",
+	-7995:  "En",
+	-9254:  "Zhen",
 	-30747: "Jiong",
 	-31796: "Tian",
+	-8776:  "Wan",
+	-6745:  "Pu",
+	-7182:  "Lu",
+	-6928:  "Luo",
+	-9743:  "Bo",
+	-9767:  "Dan",
 }
 
 var pyValue = []int{


### PR DESCRIPTION
Add pinyin key-value to tablemap for fix some issue(china province name and city name). Please reference pinyin_test.go & table.go code comments.

The following chinese word output error pinyin: Zuo.
/*
Add following test case for last version: 204-03-08
str:莞, code:-8776
str:濮, code:-6745
str:泸, code:-7182
str:漯, code:-6928
str:亳, code:-9743
str:儋, code:-9767
*/
